### PR TITLE
Change of retainedStorage test to work with React Native applications

### DIFF
--- a/src/manuh.js
+++ b/src/manuh.js
@@ -8,7 +8,7 @@ debug('simpleStorage', simpleStorage);
 
 var _manuhData = {
 
-    retainedStorage: typeof(window) != 'undefined' ? window.localStorage : simpleStorage,
+    retainedStorage: typeof(window) == 'undefined' || (typeof(navigator) != 'undefined' && navigator.product == 'ReactNative') ? simpleStorage : window.localStorage,
     /*
     ·         “sport/tennis/player1”
     ·         “sport/tennis/player1/ranking”


### PR DESCRIPTION
When we try to use retained function on React Native, the application broke with the message, retainedStorage is undefined, because the application try to use window.localStorage that cannot be used.
Changing the test, to window or React Native application, the problem was solved.